### PR TITLE
Update tcurr to fix APD

### DIFF
--- a/modules/gpu.cu
+++ b/modules/gpu.cu
@@ -75,7 +75,7 @@ __device__ void kernel_DoDrugSim(double *d_ic50, double *d_cvar, double *d_CONST
     bool is_peak = false;
     // to search max dvmdt repol
 
-    tcurr[sample_id] = 0.000001;
+    tcurr[sample_id] = 0.0;
     dt[sample_id] = p_param->dt;
     double tmax;
     double max_time_step = 1.0, time_point = 25.0;

--- a/modules/gpu.cu
+++ b/modules/gpu.cu
@@ -520,7 +520,7 @@ __device__ void kernel_DoDrugSim_single(double *d_ic50, double *d_cvar, double *
     bool is_peak = false;
     // to search max dvmdt repol
 
-    tcurr[sample_id] = 0.000001;
+    tcurr[sample_id] = 0.0;
     dt[sample_id] = p_param->dt;
     double tmax;
     double max_time_step = 1.0, time_point = 25.0;


### PR DESCRIPTION
When curr did not start from 0, it snowballed the error and skewed the results highly 